### PR TITLE
PR D (luminis-foundation-open): Align paper citations with Zenodo record

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > *Bridging Mycelium-Inspired Decentralized Computing and Symbiotic Plant–Fungal–AI Bio-Hybrid Systems in Northern New Mexico's High-Desert Ecosystems*
 >
-> Garcia, C., Kimble, A., Martin, G., & VanKaujk, S. (2026). Zenodo. [https://doi.org/10.5281/zenodo.20143391](https://doi.org/10.5281/zenodo.20143391)
+> Garcia, C. (2026). *Bridging Mycelium-Inspired Decentralized Computing and Symbiotic Plant–Fungal–AI Bio-Hybrid Systems in Northern New Mexico's High-Desert Ecosystems.* Zenodo. [https://doi.org/10.5281/zenodo.20143391](https://doi.org/10.5281/zenodo.20143391)
 
 ---
 

--- a/governance/vision.md
+++ b/governance/vision.md
@@ -17,7 +17,7 @@ Luminis Foundation envisions a future where intelligence is decentralized, ecolo
 
 In Northern New Mexico's high-desert ecosystems, we are developing bio-hybrid systems where AI, plants, and fungi collaborate at the edge. Sensor nodes nestled in piñon-juniper woodlands. Mycelial network topologies routing data through living substrates. Intelligence that runs on soil moisture cycles and seasonal rhythms.
 
-This is not a metaphor. It's an engineering program grounded in published research ([Garcia et al., 2026](https://doi.org/10.5281/zenodo.20143391)) and headed toward field deployment in the Pecos watershed.
+This is not a metaphor. It's an engineering program grounded in published research ([Garcia, 2026](https://doi.org/10.5281/zenodo.20143391)) and headed toward field deployment in the Pecos watershed.
 
 ## Long-Term Direction
 

--- a/research/publications/2026-garcia.md
+++ b/research/publications/2026-garcia.md
@@ -1,6 +1,6 @@
 # Bridging Mycelium-Inspired Decentralized Computing and Symbiotic Plant–Fungal–AI Bio-Hybrid Systems in Northern New Mexico's High-Desert Ecosystems
 
-**Authors:** Garcia, C., Kimble, A., Martin, G., & VanKaujk, S.
+**Authors:** Garcia, C.
 
 **Year:** 2026
 
@@ -25,7 +25,7 @@ This paper explores the intersection of mycelium-inspired decentralized computin
 ```bibtex
 @article{garcia2026bridging,
   title={Bridging Mycelium-Inspired Decentralized Computing and Symbiotic Plant--Fungal--AI Bio-Hybrid Systems in Northern New Mexico's High-Desert Ecosystems},
-  author={Garcia, Carlos and Kimble, Adam and Martin, Guillermo and VanKaujk, Sterling},
+  author={Garcia, Carlos},
   year={2026},
   doi={10.5281/zenodo.20143391},
   publisher={Zenodo}


### PR DESCRIPTION
## PR D: Authorship — luminis-foundation-open

### Changes
1. **`README.md`** — Citation updated to Garcia sole author with full title
2. **`governance/vision.md`** — "Garcia et al." → "Garcia, 2026"
3. **`research/publications/2026-garcia-et-al.md`** → **`2026-garcia.md`** (renamed, co-authors removed)

Board members remain listed as officers. Only paper citations are corrected.

**Note:** Authorship discrepancy resolved per live Zenodo record (Garcia sole author).